### PR TITLE
Fix compile warning and learn clean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+lssecret

--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,7 @@ lssecret: lssecret.cpp
 install: lssecret
 	install -Dsm777 $< $(DESTDIR)/bin/$<
 
+clean:
+	rm -f lssecret
+
 .PHONY: all install

--- a/lssecret.cpp
+++ b/lssecret.cpp
@@ -117,11 +117,11 @@ void handle_error(GError *err, bool fatal) {
 	if (err == NULL) return;
 
 	if (err->domain != SECRET_ERROR) {
-		std::cerr << "Error: Couldn't get secret service for unkown reason\n";
+		std::cerr << "Error: Couldn't get secret service for unknown reason\n";
 	} else {
 		switch (err->code) {
 			case SECRET_ERROR_PROTOCOL:
-				std::cerr << "Error: Recieived invalid data from secret Service\n";
+				std::cerr << "Error: Received invalid data from secret Service\n";
 				break;
 			case SECRET_ERROR_IS_LOCKED:
 				std::cerr << "Error: Secret item or collection is locked\n";

--- a/lssecret.cpp
+++ b/lssecret.cpp
@@ -101,7 +101,7 @@ void show_secret(SecretItem *item) {
 		gsize len;
 		const gchar *value = secret_value_get(val, &len);
 		// value is not nessesarily null terminated
-		std::printf("Secret:\t%.*s\n", len, value);
+		std::printf("Secret:\t%.*s\n", int(len), value);
 		secret_value_unref(val);
 	}
 }


### PR DESCRIPTION
This PR:
* adds a `clean` target to the make file (i.e. rm the compiled file)
* ignores the compiled file to prevent accidental versionning
* fixes a warning for gsize > int cast in printf expression at compilation
* ... and additionally fixes some typos